### PR TITLE
Use Mockery\Expectation instead of CompositeExpectation

### DIFF
--- a/src/Mockery/Type/ExpectationAfterStubDynamicReturnTypeExtension.php
+++ b/src/Mockery/Type/ExpectationAfterStubDynamicReturnTypeExtension.php
@@ -32,7 +32,7 @@ class ExpectationAfterStubDynamicReturnTypeExtension implements DynamicMethodRet
 
 	public function getTypeFromMethodCall(MethodReflection $methodReflection, MethodCall $methodCall, Scope $scope): Type
 	{
-		return new ObjectType('Mockery\\CompositeExpectation');
+		return new ObjectType('Mockery\\Expectation');
 	}
 
 }

--- a/src/Mockery/Type/ShouldReceiveDynamicReturnTypeExtension.php
+++ b/src/Mockery/Type/ShouldReceiveDynamicReturnTypeExtension.php
@@ -24,7 +24,7 @@ class ShouldReceiveDynamicReturnTypeExtension implements DynamicMethodReturnType
 
 	public function getTypeFromMethodCall(MethodReflection $methodReflection, MethodCall $methodCall, Scope $scope): Type
 	{
-		return new ObjectType('Mockery\\CompositeExpectation');
+		return new ObjectType('Mockery\\Expectation');
 	}
 
 }

--- a/tests/Mockery/MockeryBarTest.php
+++ b/tests/Mockery/MockeryBarTest.php
@@ -21,4 +21,17 @@ class MockeryBarTest extends \PHPUnit\Framework\TestCase
 		self::assertSame('foo', $bar->doFoo());
 	}
 
+	public function testExpectationMethodsAreCalled(): void
+	{
+		$bar = new Bar($this->fooMock);
+
+		$this->fooMock
+			->shouldReceive('doFoo')
+			->once()
+			->times(1)
+			->andReturn('foo');
+
+		self::assertSame('foo', $bar->doFoo());
+	}
+
 }


### PR DESCRIPTION
Prevent errors like

> Call to an undefined method Mockery\CompositeExpectation::times()

or

> Call to an undefined method Mockery\CompositeExpectation::once().

Would deserve patch release if merged.