### PR TITLE
Add handling for more complex declaration syntax

### DIFF
--- a/tests/Mockery/Baz.php
+++ b/tests/Mockery/Baz.php
@@ -1,0 +1,10 @@
+<?php declare(strict_types = 1);
+
+namespace PHPStan\Mockery;
+
+interface Baz
+{
+
+	public function doFoo(): ?string;
+
+}

--- a/tests/Mockery/Buzz.php
+++ b/tests/Mockery/Buzz.php
@@ -1,0 +1,10 @@
+<?php declare(strict_types = 1);
+
+namespace PHPStan\Mockery;
+
+interface Buzz
+{
+
+	public function doBuzz(): ?string;
+
+}

--- a/tests/Mockery/Foo.php
+++ b/tests/Mockery/Foo.php
@@ -2,12 +2,20 @@
 
 namespace PHPStan\Mockery;
 
-class Foo
+class Foo implements Baz
 {
+
+	/** @var bool */
+	private $optional;
+
+	public function __construct(bool $optional = true)
+	{
+		$this->optional = $optional;
+	}
 
 	public function doFoo(): ?string
 	{
-		if (rand(0, 1) === 0) {
+		if ($this->optional) {
 			return null;
 		}
 

--- a/tests/Mockery/IsolatedMockeryTest.php
+++ b/tests/Mockery/IsolatedMockeryTest.php
@@ -1,0 +1,33 @@
+<?php declare(strict_types = 1);
+
+namespace PHPStan\Mockery;
+
+/**
+ * @runTestsInSeparateProcesses
+ */
+class IsolatedMockeryTest extends \PHPUnit\Framework\TestCase
+{
+
+	public function testAliasMock(): void
+	{
+		$fooMock = \Mockery::mock('alias:' . Foo::class);
+		$this->requireFoo($fooMock);
+
+		$fooMock->shouldReceive('doFoo')->andReturn('bar');
+		self::assertSame('bar', $fooMock->doFoo());
+	}
+
+	public function testOverloadMock(): void
+	{
+		$fooMock = \Mockery::mock('overload:' . Foo::class);
+		$this->requireFoo($fooMock);
+
+		$fooMock->shouldReceive('doFoo')->andReturn('bar');
+		self::assertSame('bar', $fooMock->doFoo());
+	}
+
+	private function requireFoo(Foo $foo): void
+	{
+	}
+
+}

--- a/tests/Mockery/MockeryTest.php
+++ b/tests/Mockery/MockeryTest.php
@@ -86,6 +86,15 @@ class MockeryTest extends \PHPUnit\Framework\TestCase
 		self::assertSame('bar', $fooMock->doFoo());
 	}
 
+	public function testMockWithMethods(): void
+	{
+		$fooMock = \Mockery::mock(Foo::class . '[doFoo]');
+		$this->requireFoo($fooMock);
+
+		$fooMock->allows()->doFoo()->andReturns('foo');
+		self::assertSame('foo', $fooMock->doFoo());
+	}
+
 	private function requireFoo(Foo $foo): void
 	{
 	}

--- a/tests/Mockery/MockeryTest.php
+++ b/tests/Mockery/MockeryTest.php
@@ -46,7 +46,55 @@ class MockeryTest extends \PHPUnit\Framework\TestCase
 		self::assertSame('foo', $this->fooMock->doFoo());
 	}
 
+	public function testMockInterface(): void
+	{
+		$interfaceMock = \Mockery::mock(Baz::class, Buzz::class);
+		$this->requireBaz($interfaceMock);
+		$this->requireBuzz($interfaceMock);
+
+		$interfaceMock->shouldReceive('doFoo')->andReturn('bar');
+		self::assertSame('bar', $interfaceMock->doFoo());
+	}
+
+	public function testMockFooWithInterfaces(): void
+	{
+		$fooMock = \Mockery::mock(Foo::class, Baz::class . ', ' . Buzz::class);
+		$this->requireFoo($fooMock);
+		$this->requireBaz($fooMock);
+		$this->requireBuzz($fooMock);
+
+		$fooMock->shouldReceive('doFoo')->andReturn('bar');
+		self::assertSame('bar', $fooMock->doFoo());
+	}
+
+	public function testMockWithConstructorArgs(): void
+	{
+		$fooMock = \Mockery::mock(Foo::class, [true]);
+		$this->requireFoo($fooMock);
+
+		$fooMock->shouldReceive('doFoo')->andReturn('bar');
+		self::assertSame('bar', $fooMock->doFoo());
+	}
+
+	public function testMockWithInterfaceAndConstructorArgs(): void
+	{
+		$fooMock = \Mockery::mock(Foo::class, Buzz::class, [true]);
+		$this->requireFoo($fooMock);
+		$this->requireBuzz($fooMock);
+
+		$fooMock->shouldReceive('doFoo')->andReturn('bar');
+		self::assertSame('bar', $fooMock->doFoo());
+	}
+
 	private function requireFoo(Foo $foo): void
+	{
+	}
+
+	private function requireBaz(Baz $baz): void
+	{
+	}
+
+	private function requireBuzz(Buzz $buzz): void
 	{
 	}
 


### PR DESCRIPTION
Support the following declaration options
 - alias:
 - overload:
 - Multiple interface names
 - Constructor arguments
 - Method declaration