### PR TITLE
Fix/should allow mocking protected methods

### DIFF
--- a/stubs/MockInterface.stub
+++ b/stubs/MockInterface.stub
@@ -32,6 +32,11 @@ interface LegacyMockInterface
 	 */
 	public function makePartial();
 
+    /**
+     * @return static
+     */
+    public function shouldAllowMockingProtectedMethods();
+
 }
 
 class Expectation

--- a/tests/Mockery/MockeryTest.php
+++ b/tests/Mockery/MockeryTest.php
@@ -95,6 +95,15 @@ class MockeryTest extends \PHPUnit\Framework\TestCase
 		self::assertSame('foo', $fooMock->doFoo());
 	}
 
+	public function testMockShouldAllowMockingProtectedMethods(): void
+	{
+		$fooMock = \Mockery::mock(Foo::class)->shouldAllowMockingProtectedMethods();
+		$this->requireFoo($fooMock);
+
+		$fooMock->shouldReceive('doFoo')->once()->andReturn('bar');
+		self::assertSame('bar', $fooMock->doFoo());
+	}
+
 	public function testMakePartial(): void
 	{
 		$fooMock = \Mockery::mock(Foo::class)->makePartial();


### PR DESCRIPTION
Fix return type of shouldAllowMockingProtectedMethods with phpstan stubs