### PR TITLE
Return an intersection type when nameMock is used

### DIFF
--- a/extension.neon
+++ b/extension.neon
@@ -53,6 +53,11 @@ services:
 			- phpstan.broker.dynamicStaticMethodReturnTypeExtension
 
 	-
+		class: PHPStan\Mockery\Type\MockDynamicNamedMockReturnTypeExtension
+		tags:
+			- phpstan.broker.dynamicStaticMethodReturnTypeExtension
+
+	-
 		class: PHPStan\Mockery\PhpDoc\TypeNodeResolverExtension
 		tags:
 			- phpstan.phpDoc.typeNodeResolverExtension

--- a/src/Mockery/Type/MockDynamicNamedMockReturnTypeExtension.php
+++ b/src/Mockery/Type/MockDynamicNamedMockReturnTypeExtension.php
@@ -33,7 +33,9 @@ class MockDynamicNamedMockReturnTypeExtension implements DynamicStaticMethodRetu
 		$defaultReturnType = new ObjectType('Mockery\\MockInterface');
 
 		$args = $methodCall->args;
-		array_shift($args);
+		if (count($args) > 1) {
+			array_shift($args);
+		}
 
 		$types = [$defaultReturnType];
 		foreach ($args as $arg) {

--- a/src/Mockery/Type/MockDynamicNamedMockReturnTypeExtension.php
+++ b/src/Mockery/Type/MockDynamicNamedMockReturnTypeExtension.php
@@ -1,0 +1,70 @@
+<?php declare(strict_types = 1);
+
+namespace PHPStan\Mockery\Type;
+
+use PhpParser\Node\Expr\StaticCall;
+use PHPStan\Analyser\Scope;
+use PHPStan\Reflection\MethodReflection;
+use PHPStan\Type\Constant\ConstantStringType;
+use PHPStan\Type\DynamicStaticMethodReturnTypeExtension;
+use PHPStan\Type\ObjectType;
+use PHPStan\Type\Type;
+use PHPStan\Type\TypeCombinator;
+
+class MockDynamicNamedMockReturnTypeExtension implements DynamicStaticMethodReturnTypeExtension
+{
+
+	public function getClass(): string
+	{
+		return 'Mockery';
+	}
+
+	public function isStaticMethodSupported(MethodReflection $methodReflection): bool
+	{
+		return $methodReflection->getName() === 'namedMock';
+	}
+
+	public function getTypeFromStaticMethodCall(
+		MethodReflection $methodReflection,
+		StaticCall $methodCall,
+		Scope $scope
+	): Type
+	{
+		$defaultReturnType = new ObjectType('Mockery\\MockInterface');
+
+		$args = $methodCall->args;
+		array_shift($args);
+
+		$types = [$defaultReturnType];
+		foreach ($args as $arg) {
+			$classType = $scope->getType($arg->value);
+			if (!$classType instanceof ConstantStringType) {
+				continue;
+			}
+
+			$value = $classType->getValue();
+			if (substr($value, 0, 6) === 'alias:') {
+				$value = substr($value, 6);
+			}
+			if (substr($value, 0, 9) === 'overload:') {
+				$value = substr($value, 9);
+			}
+			if (substr($value, -1) === ']' && strpos($value, '[') !== false) {
+				$value = substr($value, 0, strpos($value, '['));
+			}
+
+			if (strpos($value, ',') !== false) {
+				$interfaceNames = explode(',', str_replace(' ', '', $value));
+			} else {
+				$interfaceNames = [$value];
+			}
+
+			foreach ($interfaceNames as $name) {
+				$types[] = new ObjectType($name);
+			}
+		}
+
+		return TypeCombinator::intersect(...$types);
+	}
+
+}

--- a/src/Mockery/Type/MockDynamicReturnTypeExtension.php
+++ b/src/Mockery/Type/MockDynamicReturnTypeExtension.php
@@ -23,6 +23,7 @@ class MockDynamicReturnTypeExtension implements DynamicStaticMethodReturnTypeExt
 	{
 		return in_array($methodReflection->getName(), [
 			'mock',
+			'namedMock'
 			'spy',
 		], true);
 	}

--- a/src/Mockery/Type/MockDynamicReturnTypeExtension.php
+++ b/src/Mockery/Type/MockDynamicReturnTypeExtension.php
@@ -23,7 +23,6 @@ class MockDynamicReturnTypeExtension implements DynamicStaticMethodReturnTypeExt
 	{
 		return in_array($methodReflection->getName(), [
 			'mock',
-			'namedMock',
 			'spy',
 		], true);
 	}

--- a/src/Mockery/Type/MockDynamicReturnTypeExtension.php
+++ b/src/Mockery/Type/MockDynamicReturnTypeExtension.php
@@ -39,13 +39,8 @@ class MockDynamicReturnTypeExtension implements DynamicStaticMethodReturnTypeExt
 			return $defaultReturnType;
 		}
 
-		$args = $methodCall->args;
-		if ($methodReflection->getName() === 'namedMock') {
-			array_shift($args);
-		}
-
 		$types = [$defaultReturnType];
-		foreach ($args as $arg) {
+		foreach ($methodCall->args as $arg) {
 			$classType = $scope->getType($arg->value);
 			if (!$classType instanceof ConstantStringType) {
 				continue;

--- a/src/Mockery/Type/MockDynamicReturnTypeExtension.php
+++ b/src/Mockery/Type/MockDynamicReturnTypeExtension.php
@@ -39,8 +39,13 @@ class MockDynamicReturnTypeExtension implements DynamicStaticMethodReturnTypeExt
 			return $defaultReturnType;
 		}
 
+		$args = $methodCall->args;
+		if ($methodReflection->getName() === 'namedMock') {
+			array_shift($args);
+		}
+
 		$types = [$defaultReturnType];
-		foreach ($methodCall->args as $arg) {
+		foreach ($args as $arg) {
 			$classType = $scope->getType($arg->value);
 			if (!$classType instanceof ConstantStringType) {
 				continue;

--- a/src/Mockery/Type/MockDynamicReturnTypeExtension.php
+++ b/src/Mockery/Type/MockDynamicReturnTypeExtension.php
@@ -23,7 +23,7 @@ class MockDynamicReturnTypeExtension implements DynamicStaticMethodReturnTypeExt
 	{
 		return in_array($methodReflection->getName(), [
 			'mock',
-			'namedMock'
+			'namedMock',
 			'spy',
 		], true);
 	}

--- a/tests/Mockery/MockeryTest.php
+++ b/tests/Mockery/MockeryTest.php
@@ -115,7 +115,6 @@ class MockeryTest extends \PHPUnit\Framework\TestCase
 
 	public function testNamedMock(): void
 	{
-		// $fooMock = \Mockery::namedMock('FooBar');
 		$fooMock = \Mockery::namedMock('FooBar', Foo::class);
 		$this->requireFoo($fooMock);
 

--- a/tests/Mockery/MockeryTest.php
+++ b/tests/Mockery/MockeryTest.php
@@ -113,6 +113,16 @@ class MockeryTest extends \PHPUnit\Framework\TestCase
 		self::assertSame('foo', $fooMock->doFoo());
 	}
 
+	public function testNamedMock(): void
+	{
+		// $fooMock = \Mockery::namedMock('FooBar');
+		$fooMock = \Mockery::namedMock('FooBar', Foo::class);
+		$this->requireFoo($fooMock);
+
+		$fooMock->allows()->doFoo()->andReturns('foo');
+		self::assertSame('foo', $fooMock->doFoo());
+	}
+
 	private function requireFoo(Foo $foo): void
 	{
 	}


### PR DESCRIPTION
This will return intersetion type when [`namedMock`](http://docs.mockery.io/en/latest/reference/creating_test_doubles.html#named-mocks) function is used.

Currently when `Mockery::namedMock()` is used within tests PHPStan complains that the mocked object does not conform to what is expected.

```php
interface Bar {}

class Foo
{
    public function foo(Bar $bar) {
        $this->bar = $bar;
    }
}

// Works
$mock = Mockery::mock(Bar::class);
(new Foo)->foo($mock);

// Does not work
// Parameter #1 $bar of method Foo::foo() expects Bar, Mockery\MockInterface given. 
$namedMock = Mockery::namedMock('Buzz', Bar::class);
(new Foo)->foo($namedMock);
```