### PR TITLE
Fix type hint of $methodNames argument in MockInterface.stub

### DIFF
--- a/stubs/MockInterface.stub
+++ b/stubs/MockInterface.stub
@@ -6,7 +6,7 @@ interface MockInterface
 {
 
 	/**
-	 * @param string[] ...$methodNames
+	 * @param string|array<string, mixed> ...$methodNames
 	 * @return Expectation
 	 */
 	public function shouldReceive(...$methodNames);
@@ -22,7 +22,7 @@ interface LegacyMockInterface
 {
 
 	/**
-	 * @param string[] ...$methodNames
+	 * @param string|array<string, mixed> ...$methodNames
 	 * @return Expectation
 	 */
 	public function shouldReceive(...$methodNames);

--- a/tests/Mockery/MockeryTest.php
+++ b/tests/Mockery/MockeryTest.php
@@ -38,6 +38,13 @@ class MockeryTest extends \PHPUnit\Framework\TestCase
 		self::assertSame('bar', $fooMock->doFoo());
 	}
 
+	public function testAlternativeMockTest(): void
+	{
+		$fooMock = \Mockery::mock(Foo::class);
+		$fooMock->shouldReceive(['doFoo' => 'bar']);
+		self::assertSame('bar', $fooMock->doFoo());
+	}
+
 	public function testMockFromProperty(): void
 	{
 		$this->requireFoo($this->fooMock);


### PR DESCRIPTION
https://github.com/phpstan/phpstan-mockery/issues/23