### PR TITLE
Support shouldNotReceive

### DIFF
--- a/stubs/MockInterface.stub
+++ b/stubs/MockInterface.stub
@@ -12,6 +12,12 @@ interface MockInterface
 	public function shouldReceive(...$methodNames);
 
 	/**
+	 * @param string|array<string, mixed> ...$methodNames
+	 * @return Expectation
+	 */
+	public function shouldNotReceive(...$methodNames);
+
+	/**
 	 * @return static
 	 */
 	public function makePartial();
@@ -26,6 +32,12 @@ interface LegacyMockInterface
 	 * @return Expectation
 	 */
 	public function shouldReceive(...$methodNames);
+
+	/**
+	 * @param string|array<string, mixed> ...$methodNames
+	 * @return Expectation
+	 */
+	public function shouldNotReceive(...$methodNames);
 
 	/**
 	 * @return static

--- a/tests/Mockery/MockeryBarTest.php
+++ b/tests/Mockery/MockeryBarTest.php
@@ -2,7 +2,9 @@
 
 namespace PHPStan\Mockery;
 
-class MockeryBarTest extends \PHPUnit\Framework\TestCase
+use Mockery\Adapter\Phpunit\MockeryTestCase;
+
+class MockeryBarTest extends MockeryTestCase
 {
 
 	/** @var \Mockery\MockInterface|Foo */
@@ -10,6 +12,8 @@ class MockeryBarTest extends \PHPUnit\Framework\TestCase
 
 	protected function setUp(): void
 	{
+		parent::setUp();
+
 		$this->fooMock = \Mockery::mock(Foo::class);
 	}
 
@@ -32,6 +36,19 @@ class MockeryBarTest extends \PHPUnit\Framework\TestCase
 			->andReturn('foo');
 
 		self::assertSame('foo', $bar->doFoo());
+	}
+
+	public function testShouldNotReceiveAndHaveReceived(): void
+	{
+		$this->fooMock->shouldNotReceive('doFoo')->andReturn('bar');
+		$this->fooMock->shouldNotHaveReceived('doFoo');
+	}
+
+	public function testShouldReceiveAndHaveReceived(): void
+	{
+		$this->fooMock->shouldReceive('doFoo')->andReturn('bar');
+		self::assertSame('bar', $this->fooMock->doFoo());
+		$this->fooMock->shouldHaveReceived('doFoo');
 	}
 
 }


### PR DESCRIPTION
This fixes the issue when using:

```
$this->fooMock->shouldNotReceive('doFoo')->andReturn('bar');
// Call to an undefined method Mockery\ExpectationInterface|Mockery\HigherOrderMessage::andReturn()
```

Fixes #11
Closes #9