### PR TITLE
Support shouldHaveReceive

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -20,4 +20,4 @@ cs-fix:
 
 .PHONY: phpstan
 phpstan:
-	php vendor/bin/phpstan analyse -l 8 -c phpstan.neon src tests
+	php vendor/bin/phpstan analyse -l 9 -c phpstan.neon src tests

--- a/stubs/MockInterface.stub
+++ b/stubs/MockInterface.stub
@@ -39,6 +39,20 @@ interface LegacyMockInterface
 	 */
 	public function shouldNotReceive(...$methodNames);
 
+    /**
+     * @param null|string $method
+     * @param null|array<string> $args
+     * @return Expectation
+     */
+    public function shouldHaveReceived($method, $args = null);
+
+    /**
+     * @param null|string $method
+     * @param null|array<string> $args
+     * @return Expectation
+     */
+    public function shouldNotHaveReceived($method, $args = null);
+
 	/**
 	 * @return static
 	 */

--- a/tests/Mockery/MockeryBarTest.php
+++ b/tests/Mockery/MockeryBarTest.php
@@ -40,17 +40,27 @@ class MockeryBarTest extends MockeryTestCase
 		self::assertSame('foo', $bar->doFoo());
 	}
 
-	public function testShouldNotReceiveAndHaveReceived(): void
+	public function testShouldNotReceive(): void
 	{
 		$this->fooMock->shouldNotReceive('doFoo')->andReturn('bar');
-		$this->fooMock->shouldNotHaveReceived('doFoo');
 	}
 
-	public function testShouldReceiveAndHaveReceived(): void
+	public function testShouldReceive(): void
 	{
 		$this->fooMock->shouldReceive('doFoo')->andReturn('bar');
 		self::assertSame('bar', $this->fooMock->doFoo());
-		$this->fooMock->shouldHaveReceived('doFoo');
+	}
+
+	public function testShouldNotHaveReceived(): void
+	{
+		$this->fooMock->shouldNotHaveReceived(null)->withArgs(['bar']);
+	}
+
+	public function testShouldHaveReceived(): void
+	{
+		$this->fooMock->allows('doFoo')->andReturn('bar');
+		self::assertSame('bar', $this->fooMock->doFoo());
+		$this->fooMock->shouldHaveReceived('doFoo')->once();
 	}
 
 }


### PR DESCRIPTION
Add support to shouldHaveReceive method. I do not add test as it look like already cover by `\PHPStan\Mockery\MockeryBarTest::testShouldReceiveAndHaveReceived`