### PR TITLE
Fix MockInterface::shouldHaveReceived() and MockInterface::shouldNotHaveReceived() stub methods

### DIFF
--- a/stubs/MockInterface.stub
+++ b/stubs/MockInterface.stub
@@ -41,14 +41,14 @@ interface LegacyMockInterface
 
     /**
      * @param null|string $method
-     * @param null|array<string> $args
+     * @param null|array<mixed>|\Closure $args
      * @return Expectation
      */
     public function shouldHaveReceived($method, $args = null);
 
     /**
      * @param null|string $method
-     * @param null|array<string> $args
+     * @param null|array<mixed>|\Closure $args
      * @return Expectation
      */
     public function shouldNotHaveReceived($method, $args = null);

--- a/tests/Mockery/MockeryBarTest.php
+++ b/tests/Mockery/MockeryBarTest.php
@@ -9,14 +9,18 @@ use Mockery\MockInterface;
 class MockeryBarTest extends MockeryTestCase
 {
 
-	/** @var MockInterface|Foo */
+	/** @var MockInterface&Foo */
 	private $fooMock;
+
+	/** @var MockInterface&Foo */
+	private $fooSpy;
 
 	protected function setUp(): void
 	{
 		parent::setUp();
 
 		$this->fooMock = Mockery::mock(Foo::class);
+		$this->fooSpy = Mockery::spy(Foo::class);
 	}
 
 	public function testFooIsCalled(): void
@@ -53,14 +57,24 @@ class MockeryBarTest extends MockeryTestCase
 
 	public function testShouldNotHaveReceived(): void
 	{
-		$this->fooMock->shouldNotHaveReceived(null)->withArgs(['bar']);
+		$this->fooSpy->shouldNotHaveReceived(null)->withArgs(['bar']);
+		$this->fooSpy->doBar('ccc');
+		$this->fooSpy->shouldNotHaveReceived('doBar', ['ddd']);
+		$this->fooSpy->shouldNotHaveReceived('doBar', static function (string $arg): bool {
+			return $arg !== 'ccc';
+		});
 	}
 
 	public function testShouldHaveReceived(): void
 	{
-		$this->fooMock->allows('doFoo')->andReturn('bar');
-		self::assertSame('bar', $this->fooMock->doFoo());
-		$this->fooMock->shouldHaveReceived('doFoo')->once();
+		$this->fooSpy->allows('doFoo')->andReturn('bar');
+		self::assertSame('bar', $this->fooSpy->doFoo());
+		$this->fooSpy->shouldHaveReceived('doFoo')->once();
+		$this->fooSpy->doBar('ccc');
+		$this->fooSpy->shouldHaveReceived('doBar', ['ccc']);
+		$this->fooSpy->shouldHaveReceived('doBar', static function (string $arg): bool {
+			return $arg === 'ccc';
+		});
 	}
 
 }

--- a/tests/Mockery/data/Foo.php
+++ b/tests/Mockery/data/Foo.php
@@ -22,4 +22,7 @@ class Foo implements Baz
 		return 'foo';
 	}
 
+	public function doBar(string $arg): void
+	{
+	}
 }


### PR DESCRIPTION
Fixes https://github.com/phpstan/phpstan-mockery/issues/57